### PR TITLE
Improve SEO: meta tags, sitemap, OG image, structured data

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -2,10 +2,12 @@ import { defineConfig } from 'astro/config';
 
 import react from '@astrojs/react';
 import tailwindcss from '@tailwindcss/vite';
+import sitemap from '@astrojs/sitemap';
 
 // https://astro.build/config
 export default defineConfig({
-  integrations: [react()],
+  site: 'https://nasuta.dev',
+  integrations: [react(), sitemap()],
 
   vite: {
     plugins: [tailwindcss()],

--- a/e2e/portfolio.spec.ts
+++ b/e2e/portfolio.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test('page title is set correctly', async ({ page }) => {
   await page.goto('/');
-  await expect(page).toHaveTitle('Krzysztof Nasuta');
+  await expect(page).toHaveTitle('Krzysztof Nasuta — Software Engineer');
 });
 
 test('displays personal info', async ({ page }) => {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@astrojs/react": "^6.0.0",
+    "@astrojs/sitemap": "^3.7.3",
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@fontsource/lato": "^5.2.7",
     "@lucide/astro": "^1.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@astrojs/react':
         specifier: ^6.0.0
         version: 6.0.1(@types/node@25.9.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@astrojs/sitemap':
+        specifier: ^3.7.3
+        version: 3.7.3
       '@fontsource/jetbrains-mono':
         specifier: ^5.2.8
         version: 5.2.8
@@ -224,6 +227,9 @@ packages:
       '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
       react: ^17.0.2 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+
+  '@astrojs/sitemap@3.7.3':
+    resolution: {integrity: sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==}
 
   '@astrojs/telemetry@3.3.2':
     resolution: {integrity: sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==}
@@ -1307,6 +1313,9 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
+  '@types/node@24.13.2':
+    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
+
   '@types/node@25.9.4':
     resolution: {integrity: sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==}
 
@@ -1317,6 +1326,9 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/sax@1.2.7':
+    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -1463,6 +1475,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2895,6 +2910,11 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  sitemap@9.0.1:
+    resolution: {integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==}
+    engines: {node: '>=20.19.5', npm: '>=10.8.2'}
+    hasBin: true
+
   smol-toml@1.7.0:
     resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
     engines: {node: '>= 18'}
@@ -2915,6 +2935,9 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  stream-replace-string@2.0.0:
+    resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
@@ -3064,6 +3087,9 @@ packages:
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
@@ -3481,6 +3507,12 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  '@astrojs/sitemap@3.7.3':
+    dependencies:
+      sitemap: 9.0.1
+      stream-replace-string: 2.0.0
+      zod: 4.4.3
 
   '@astrojs/telemetry@3.3.2':
     dependencies:
@@ -4321,6 +4353,10 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/node@24.13.2':
+    dependencies:
+      undici-types: 7.18.2
+
   '@types/node@25.9.4':
     dependencies:
       undici-types: 7.24.6
@@ -4332,6 +4368,10 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@types/sax@1.2.7':
+    dependencies:
+      '@types/node': 25.9.4
 
   '@types/unist@3.0.3': {}
 
@@ -4513,6 +4553,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.2
+
+  arg@5.0.2: {}
 
   argparse@2.0.1: {}
 
@@ -6262,6 +6304,13 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  sitemap@9.0.1:
+    dependencies:
+      '@types/node': 24.13.2
+      '@types/sax': 1.2.7
+      arg: 5.0.2
+      sax: 1.6.0
+
   smol-toml@1.7.0: {}
 
   source-map-js@1.2.1: {}
@@ -6276,6 +6325,8 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  stream-replace-string@2.0.0: {}
 
   string.prototype.matchall@4.0.12:
     dependencies:
@@ -6458,6 +6509,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   uncrypto@0.1.3: {}
+
+  undici-types@7.18.2: {}
 
   undici-types@7.24.6: {}
 

--- a/public/og-image.svg
+++ b/public/og-image.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630"><path fill="#18181b" d="M0 0h1200v630H0z"/><rect x="40" y="40" width="1120" height="550" rx="12" fill="none" stroke="#52525b" stroke-width="2"/><circle cx="74" cy="72" r="7" fill="#ff5f57"/><circle cx="102" cy="72" r="7" fill="#febc2e"/><circle cx="130" cy="72" r="7" fill="#28c840"/><text x="470" y="78" font-family="'JetBrains Mono', monospace" font-size="16" fill="#a1a1aa">portfolio — bash</text><path stroke="#52525b" d="M40 100h1120"/><text x="80" y="170" font-family="'JetBrains Mono', monospace" font-size="22">
+      <tspan fill="#71717a">~/portfolio</tspan>
+      <tspan fill="#34d399"> $</tspan>
+      <tspan fill="#a78bfa"> whoami</tspan>
+    </text><text font-family="'Lato', system-ui, sans-serif" font-size="120" font-weight="700" fill="#fff">
+    <tspan x="80" y="370">Krzysztof</tspan>
+    <tspan x="80" y="480">Nasuta</tspan>
+  </text></svg>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: https://nasuta.dev/sitemap-index.xml

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,17 @@
+{
+  "name": "Krzysztof Nasuta",
+  "short_name": "Nasuta",
+  "description": "Software Engineer — DevOps & Backend Engineering",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#18181b",
+  "theme_color": "#18181b",
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/src/components/CommitTimeline.tsx
+++ b/src/components/CommitTimeline.tsx
@@ -23,7 +23,7 @@ export default function CommitTimeline({
 
   // Estimate required width based on lane width, text offset, and longest title
   const maxTitleLength = Math.max(...timelineEvents.map((e) => e.title.length), 0);
-  const calculatedWidth = textX + maxTitleLength * 9;
+  const calculatedWidth = textX + maxTitleLength * 10.5;
 
   const handleNodeClick = (event: TimelineEvent) => {
     setSelectedEvent(event);

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,5 +1,18 @@
 ---
-
+import '../styles/global.css';
+import LoaderCircle from '@lucide/astro/icons/loader-circle';
 ---
 
-<meta http-equiv="refresh" content="0;url=/" />
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <meta name="robots" content="noindex" />
+    <meta http-equiv="refresh" content="0;url=/" />
+    <title>Redirecting...</title>
+  </head>
+  <body class="bg-zinc-900 min-h-screen flex items-center justify-center">
+    <LoaderCircle class="size-24 text-emerald-400 animate-spin" />
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,15 +6,70 @@ import CommitTimeline from '../components/CommitTimeline.tsx';
 import { personalInfo } from '../data';
 
 const metaDescription = personalInfo.bio.replace(/<[^>]*>/g, '').trim();
+const title = `${personalInfo.name} — ${personalInfo.role}`;
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 ---
 
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <meta name="viewport" content="width=device-width" />
+    <title>{title}</title>
     <meta name="description" content={metaDescription} />
-    <title>{personalInfo.name}</title>
+    <meta name="theme-color" content="#18181b" />
+    <meta name="color-scheme" content="dark" />
+
+    <link rel="canonical" href={canonicalURL} />
+    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
+    <link rel="apple-touch-icon" href="/icon.svg" />
+    <link rel="manifest" href="/site.webmanifest" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={metaDescription} />
+    <meta property="og:url" content={canonicalURL} />
+    <meta property="og:site_name" content={personalInfo.name} />
+    <meta property="og:image" content={new URL('/og-image.svg', Astro.url)} />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content={`Portfolio of ${personalInfo.name}`} />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={metaDescription} />
+    <meta name="twitter:image" content={new URL('/og-image.svg', Astro.url)} />
+
+    <!-- JSON-LD Structured Data -->
+    <script
+      type="application/ld+json"
+      set:html={JSON.stringify({
+        '@context': 'https://schema.org',
+        '@graph': [
+          {
+            '@type': 'Person',
+            name: personalInfo.name,
+            alternateName: personalInfo.alias,
+            jobTitle: personalInfo.role,
+            worksFor: {
+              '@type': 'Organization',
+              name: personalInfo.company,
+            },
+            email: personalInfo.email,
+            url: canonicalURL.origin,
+            sameAs: personalInfo.socials.filter((s) => s.url.startsWith('http')).map((s) => s.url),
+          },
+          {
+            '@type': 'WebSite',
+            name: personalInfo.name,
+            url: canonicalURL.origin,
+            description: metaDescription,
+          },
+        ],
+      })}
+    />
   </head>
   <body
     class="bg-zinc-900 text-zinc-400 font-sans antialiased selection:bg-zinc-800 selection:text-white lg:h-screen lg:overflow-hidden"


### PR DESCRIPTION
SEO improvements:

- Add site URL and `@astrojs/sitemap` integration
- Open Graph + Twitter Card meta tags for social previews
- JSON-LD structured data (Person + WebSite schema)
- 1200×630 OG social preview image (terminal themed)
- PWA manifest, apple-touch-icon, theme-color
- Canonical URL, meta description, robots.txt with sitemap
- Fixed timeline SVG width to prevent title truncation
- 404 page with Lucide spinner
- Updated E2E tests for new title